### PR TITLE
Add ability to kill processes before tests run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ glace [options] [sequence-of-test-files-or-folders]
 - `--chunk-retry [times]` - Number of times to retry failed chunk. Default is `0`.
 - `--chunk-timeout [sec]` - Time to execute chunk or hook, sec. Default is `180`.
 - `--uncaught [type]` - Strategy to process uncaught exceptions. Default value is `log`. Supported values are `log` just to log uncaught exceptions, `fail` to fail test if uncaught exception happened, `mocha` to use default `mocha` mechanism ([unreliable](tutorial-mocha-uncaught.html)).
+- `--kill-procs <sequence>` - List of process names separated with comma, which will be killed before tests run.
 
 `Plugins`
 - `--plugins` - Show plugins only.

--- a/lib/config.js
+++ b/lib/config.js
@@ -20,6 +20,8 @@
  * @prop {string} pluginsDir - Path to custom plugins folder.
  * @prop {string} [sessionName] - Name of tests session.
  * @prop {number} [sessionId] - ID of tests session.
+ * @prop {?string[]} [killProcs] - List of process names which will be killed
+ *  before tests run.
  * @prop {object} testrail - TestRail reporter configuration.
  * @prop {boolean} [testrail.use=false] - Activate TestRail reporter.
  * @prop {?string} [testrail.host=null] - TestRail host.
@@ -93,6 +95,11 @@ config.pluginsDir = args.pluginsDir;
 var date = new Date();
 config.sessionName = U.defVal(args.sessionName, `Session ${date.toLocaleString()}`);
 config.sessionId = date.getTime();
+
+if (args.killProcs) {
+    config.killProcs = _.filter(
+        _.map(args.killProcs.split(","), el => el.trim()));
+};
 
 config.xunit = U.defVal(config.xunit, {});
 config.xunit.use = U.defVal(args.xunit, false);

--- a/lib/help.js
+++ b/lib/help.js
@@ -88,6 +88,12 @@ module.exports = (d, cb) => {
                 choices: [ "log", "fail", "mocha" ],
                 group: "Core:",
             },
+            "kill-procs <sequence>": {
+                describe: d("List of process names separated with comma,",
+                            "which will be killed before tests run."),
+                type: "string",
+                group: "Core:",
+            },
             /* plugins */
             "plugins": {
                 describe: d("Show plugins only."),

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -17,6 +17,7 @@ var fs = require("fs");
 var path = require("path")
 
 var expect = require("chai").expect;
+var U = require("glace-utils");
 
 require("./globals");
 var ConfigError = require("./error").ConfigError;
@@ -46,6 +47,14 @@ for (var testDir of CONF.testDirs) {
 
 /* Starts session */
 session(() => {
+
+    if (CONF.killProcs) {
+        before(async () => {
+            for (var procName of CONF.killProcs) {
+                await U.killProcs(procName);
+            };
+        });
+    };
 
     for (var testDir of CONF.testDirs) {
 


### PR DESCRIPTION
Problem: Periodically it needs to kills some processes before tests run,
which may stay alive after previous tests run, for example, selenium
server or chrome browser.